### PR TITLE
update bundler gem version 1.10.6 -> 1.16.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
     fabrication (2.11.3)
     faker (1.5.0)
       i18n (~> 0.5)
+    ffi (1.9.10)
     ffi (1.9.10-java)
     ffi (1.9.10-x86-mingw32)
     geocoder (1.2.9)
@@ -325,4 +326,4 @@ DEPENDENCIES
   unicorn (= 4.6.0)
 
 BUNDLED WITH
-   1.10.6
+   1.16.6


### PR DESCRIPTION
Really small change. I got a warning recommending that I update the bundler version. No breaking changes.